### PR TITLE
Supported julia0.6 (maybe not fully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ by tag name, class, and id. Extending it is relatively simple. If you
 do, you are strongly urged to add some tests, and send me a pull
 request :)
 
-
 # Examples
 
 Fetch the Wikipedia homepage, parse it, and select the headlines from
@@ -72,7 +71,7 @@ the css query is removed from your loops and functions.
 # Spiderman's HTTP Client
 
 Spiderman's httpclient is a wrapper around
-[HTTPClient.jl](https://github.com/JuliaWeb/HTTPClient.jl) (which in
+[Requests.jl](https://github.com/JuliaWeb/Requests.jl) (which in
 turn is a wrapper around libcurl). It automatically retries up to five
 times in the event of a 503 error, or a socket read timeout (both of
 which happen with distressing frequency when scraping content from the

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
-HTTPClient
+julia 0.6
+Requests
 Gumbo

--- a/src/Spiderman.jl
+++ b/src/Spiderman.jl
@@ -1,5 +1,7 @@
 module Spiderman
 using Gumbo
+using Requests
+using AbstractTrees
 import HTTPClient
 
 include("css.jl")

--- a/src/css.jl
+++ b/src/css.jl
@@ -8,10 +8,10 @@ getattr_safe(n :: HTMLNode, a :: AbstractString) = get(n.attributes, a, no_attr_
 tag_safe(n :: HTMLText) = no_attr_uuid
 tag_safe(n :: HTMLNode) = tag(n)
 
-abstract GumboPred
+abstract type GumboPred end
 
 immutable IsTag <: GumboPred; tag; end
-IsTag(t :: AbstractString) = IsTag(symbol(t))
+IsTag(t :: AbstractString) = IsTag(Symbol(t))
 matchp(p :: IsTag, n :: HTMLNode) = tag_safe(n) == p.tag
 ==(a :: IsTag, b :: IsTag) = a.tag == b.tag
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -2,7 +2,7 @@
 function text_join{T <: HTMLNode}(ns :: Array{T})
     output = []
     for n=ns
-        for e=preorder(n)
+        for e=AbstractTrees.PreOrderDFS(n)
             if typeof(e) == HTMLText
                 push!(output, text(e))
             end

--- a/src/http.jl
+++ b/src/http.jl
@@ -1,8 +1,7 @@
 function http_get(url :: AbstractString; max_tries=10)
     resp = nothing
     try
-        # opts = HTTPC.RequestOptions()
-        resp = HTTPClient.get(url) #, opts)
+        resp = Requests.get(url) #, opts)
     catch e
         if max_tries <= 1
             throw(e)
@@ -11,7 +10,7 @@ function http_get(url :: AbstractString; max_tries=10)
         end
     end
 
-    if resp.http_code == 503
+    if resp.status == 503
         if max_tries <= 1
             throw("Error executing request : too many timeouts")
         else


### PR DESCRIPTION
Fixed (`symbol() not found`)
Moved from HTTPClient to Requests
Updated `preorder` to `AbstractTrees.PreOrderDFS`